### PR TITLE
chore(pub-file-sharing): change file descriptors to string from enum …

### DIFF
--- a/gdcdictionary/schemas/publication.yaml
+++ b/gdcdictionary/schemas/publication.yaml
@@ -52,6 +52,11 @@ properties:
     type: string
   doi:
     type: string
+  first_author:
+    description: First author of paper (last name, initials)
+    type: string
+  year:
+    type: integer
   projects:
     $ref: "_definitions.yaml#/to_many_project"
   project_id:

--- a/gdcdictionary/schemas/reference_file.yaml
+++ b/gdcdictionary/schemas/reference_file.yaml
@@ -67,73 +67,17 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum:
-      - Analysis Information
-      - Annotation Reference
-      - Clinical Data
-      - Familial Reference
-      - Sequencing Reference
-      - Variant Calling Reference 
-      - Other
+    type: string
 
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"
-    enum:
-      - Kinship Matrix
-      - Principal Component      
-      - Script
-      - Sequencing Reference
-      - Unharmonized Clinical Data
-      - Variant Annotation
-      - Variant Call
-      - Other
+    type: string
 
   data_format:
     term:
       $ref: "_terms.yaml#/data_format"
-    enum:
-      - ALT
-      - AMB
-      - ANN
-      - AVRO
-      - BCF
-      - BED
-      - BWT
-      - DOCX
-      - FAI
-      - FASTA
-      - GDS
-      - GZ
-      - MD
-      - PAC
-      - POS
-      - R
-      - RDATA
-      - SA
-      - TAR
-      - TBI
-      - TSV
-      - TXT
-      - VCF
-      - XML
-      
-  callset:
-    description: >
-      Periodically, the TOPMed Informatics Research Center (IRC) performs variant identification and genotype calling on all samples available at a given time and the resulting call set is referred to as a genotype "Freeze".
     type: string
-    
-  study_version:
-    description: >
-      The version of the study that was released by data source (e.g., dbGaP)
-    type: number
-    
-  bucket_path:
-    description: >
-      The directory levels of the file as it would be found in the AWS and/or GCP bucket.
-    type: array
-    items: 
-      type: string
     
   publications:
     $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
Jira Ticket: None

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

The pull request is intended to facilitate sharing of files associated with publications within the Exchange-Area project. Specifically, it does the following:

- Adds ``first_author`` and publication year (``year``) properties to the ``publication`` node
- Changes ``data_category``, ``data_type`` and ``data_format`` properties for the ``reference_file`` node from enum to string, to avoid constant data model updates as we begin to make use of this functionality

### Dependency updates


### Deployment changes

There are currently no records associated with either node, so hopefully this will not require any data migration.